### PR TITLE
Version Updates and Fix of target Platform Generation

### DIFF
--- a/.project
+++ b/.project
@@ -5,6 +5,11 @@
 	<projects>
 	</projects>
 	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.buildship.core.gradleprojectbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.buildship.core.gradleprojectnature</nature>

--- a/.settings/org.eclipse.buildship.core.prefs
+++ b/.settings/org.eclipse.buildship.core.prefs
@@ -1,4 +1,3 @@
-connection.gradle.distribution=GRADLE_DISTRIBUTION(WRAPPER)
 connection.project.dir=
 derived.resources=.gradle,build
 eclipse.preferences.version=1

--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,11 @@
 buildscript {
 	repositories.jcenter()
 	dependencies {
-		classpath 'org.xtext:xtext-gradle-plugin:1.0.15'
+		classpath 'org.xtext:xtext-gradle-plugin:1.0.21'
 	}
 }
 
-ext.xtextVersion = '2.10.0'
+ext.xtextVersion = '2.14.0'
 
 subprojects {
 	group = 'io.typefox.gradle'

--- a/gradle-p2gen/.project
+++ b/gradle-p2gen/.project
@@ -15,6 +15,11 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.buildship.core.gradleprojectbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.buildship.core.gradleprojectnature</nature>

--- a/gradle-p2gen/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/gradle-p2gen/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -22,5 +22,5 @@ outlet.DEFAULT_OUTPUT.installDslAsPrimarySource=false
 outlet.DEFAULT_OUTPUT.keepLocalHistory=false
 outlet.DEFAULT_OUTPUT.override=true
 outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=true
-targetJavaVersion=JAVA5
+targetJavaVersion=JAVA8
 useJavaCompilerCompliance=true

--- a/gradle-p2gen/src/main/java/io/typefox/gradle/p2gen/P2GenPlugin.xtend
+++ b/gradle-p2gen/src/main/java/io/typefox/gradle/p2gen/P2GenPlugin.xtend
@@ -317,7 +317,7 @@ class P2GenPlugin implements Plugin<Project> {
 	def private generateTargetFile() '''
 		<?xml version="1.0" encoding="UTF-8"?>
 		<?pde version="3.8"?>
-		<target name="org.eclipse.xtext.helios.target" sequenceNumber="0">
+		<target name="org.eclipse.«name.replace('-',".")».target" sequenceNumber="0">
 			<locations>
 				«FOR dep : p2gen.dependencies»
 					<location includeAllPlatforms="false" includeConfigurePhase="«dep.includeConfigurePhase»" includeMode="planner" includeSource="«dep.includeSource»" type="InstallableUnit">


### PR DESCRIPTION
(1) update versions of xtext/xtext gradle plugin to latest
(2) generate java 8 xtend code
(3) updated buildship generated eclipse metadata files
(4) generated target files differently - dont use helios but the name of the project in target platforms names (fixes https://github.com/eclipse/xtext/issues/1220)